### PR TITLE
Patch

### DIFF
--- a/app.py
+++ b/app.py
@@ -2011,7 +2011,7 @@ class TAR1090Monitor:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.log_file = self.data_dir / "circle_detections.csv"
         self.grid_log_file = self.data_dir / "grid_detections.csv"
-        self.tar1090_base_url = os.environ.get("TAR1090_URL", "https://adsb.lol")
+        self.tar1090_base_url = os.environ.get("TAR1090_URL")
         
         # Display settings
         self.terminal_size = shutil.get_terminal_size((80, 24))
@@ -2933,8 +2933,8 @@ class TAR1090Monitor:
 def main():
     parser = argparse.ArgumentParser(description='Monitor TAR1090 for aircraft performing circles')
     parser.add_argument('--server', '-s',
-                        default=os.environ.get("TAR1090_URL", "https://adsb.lol"),
-                        help='TAR1090 server URL (default: value of TAR1090_URL env var or https://adsb.lol)')
+                        default=os.environ.get("TAR1090_URL"),
+                        help='TAR1090 server URL (default: value of TAR1090_URL env var)')
     parser.add_argument('--interval', '-i', type=int, default=5,
                         help='Update interval in seconds (default: 5)')
     parser.add_argument('--min-radius', type=float, default=0.5,


### PR DESCRIPTION
app.py pulls TAR1090_URL envar for use in UI and in the csv files

seems like having `self.tar1090_base_url` is kind of superfluous since `server_url` is the same thing and acquired at startup, but nevermind 

Ideally, a second button would be presented in the history screen to open the plane in an aggregator of the user's choosing, specified in another envar, e.g.

<img width="389" height="226" alt="image" src="https://github.com/user-attachments/assets/423369d6-63ec-4641-839f-424fdd559a25" />

something for later

also the app needs a favicon